### PR TITLE
Add dynamic repo mapping to ProjectSidebar

### DIFF
--- a/src/Components/Features/Koxland/ProjectRoute/Headers/ProjectHeader.jsx
+++ b/src/Components/Features/Koxland/ProjectRoute/Headers/ProjectHeader.jsx
@@ -8,7 +8,7 @@ const ProjectHeader = () => {
     <header className="sticky top-0 z-50 border-b border-slate-700/50 bg-slate-900/80 backdrop-blur-xl">
       <div className="container mx-auto flex items-center justify-between px-6 py-4">
         <button
-          onClick={() => router.push('/#projects')}
+          onClick={() => router.back()}
           className="group hover:backdrop-lg inline-flex h-8 cursor-pointer items-center justify-center gap-2 rounded-md px-3 text-xs font-medium whitespace-nowrap text-slate-400 transition-all duration-300 hover:text-white focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
         >
           <ArrowLeftIcon className="mr-2 h-4 w-4 transition-transform group-hover:-translate-x-1" />

--- a/src/Components/Features/Koxland/ProjectRoute/Views/Projects/Sidebar/ProjectSidebar.jsx
+++ b/src/Components/Features/Koxland/ProjectRoute/Views/Projects/Sidebar/ProjectSidebar.jsx
@@ -3,8 +3,9 @@ import TechStackCard from './TechStackCard';
 import ProjectLinksCard from './ProjectLinksCard';
 import GitRepoAnimatedList from '@/Components/Features/Github/Components/Repos/Components/GitRepoAnimatedList/GitRepoAnimatedList';
 import GitRepoActivityList from '@/Components/Features/Github/GitRepoActivityList';
+import repoMap from '@/Data/Projects/repoMap';
 
-const ProjectSidebar = ({ technologies, url, urlGit, pageSize }) => {
+const ProjectSidebar = ({ technologies, projectId, url, urlGit, pageSize }) => {
   return (
     <div className="grid grid-rows-[auto_auto_1fr] space-y-8">
       <TechStackCard technologies={technologies} />
@@ -12,10 +13,10 @@ const ProjectSidebar = ({ technologies, url, urlGit, pageSize }) => {
       {/* <GitRepoAnimatedList pageSizeNumber={pageSize} showMore /> */}
       <GitRepoActivityList
         owner="Koxone"
-        repo="FitWorldShop-Ecommerce-Next-Tailwind-Shopify-API"
         pageSize={5}
         refreshMs={300000}
         showMore
+        repo={repoMap[projectId]}
         padding="py-3"
       />
     </div>

--- a/src/Data/Projects/repoMap.js
+++ b/src/Data/Projects/repoMap.js
@@ -1,0 +1,12 @@
+// src/Data/Projects/repoMap.js
+const repoMap = {
+  fws: 'FitWorldShop-Ecommerce-Next-Tailwind-Shopify-API',
+  testigoMX: 'TestigoMX-Next-Tailwind-Firebase-VercelBlob-API',
+  couponGenerator: 'Sacbe-Coupon-Generator-React-Tailwind',
+  nexum: 'NexumHub-Next-Tailwind-Firebase',
+  tetris: 'Tetris-Tailwind-Javascript',
+  planet: 'Planet-Fact-React-Tailwind',
+  tictactoe: 'TicTacToe-React-Tailwind',
+};
+
+export default repoMap;

--- a/src/app/project/[id]/page.jsx
+++ b/src/app/project/[id]/page.jsx
@@ -59,6 +59,7 @@ export default function ProjectPage({ params }) {
             />
           </div>
           <ProjectSidebar
+            projectId={id}
             pageSize={3}
             technologies={project.technologies}
             url={project.url}


### PR DESCRIPTION
Introduced a repoMap utility to map project IDs to GitHub repo names, allowing ProjectSidebar to display activity for the correct repository based on the current project. Updated ProjectSidebar and its usage to accept projectId and use the mapped repo name. Changed ProjectHeader back button to use router.back().