### PR TITLE
Refactor chat button state hydration and logic

### DIFF
--- a/src/Components/Features/Sidebar/Components/Menu/Components/MenuButton.jsx
+++ b/src/Components/Features/Sidebar/Components/Menu/Components/MenuButton.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useKxChat } from '@/Stores/useKxChat';
 import { useOpenChatButton } from '@/Stores/useOpenChatButton';
 
@@ -14,8 +14,13 @@ function MenuButton({
   contact,
   textColor = '',
   downloadResume = false,
-  openChatButton = false, // 👉 nuevo prop
+  openChatButton = false,
 }) {
+  const { hydrate } = useOpenChatButton();
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
   // Zustand
   const { isOpenKxChat, openChat, toggleChat } = useKxChat();
   const { isPermitted, permitted } = useOpenChatButton();

--- a/src/Components/Features/Sidebar/Components/Menu/SidebarMenu.jsx
+++ b/src/Components/Features/Sidebar/Components/Menu/SidebarMenu.jsx
@@ -30,6 +30,10 @@ import { useOpenChatButton } from '@/Stores/useOpenChatButton';
 
 function SidebarMenu() {
   const router = useRouter();
+  const { hydrate } = useOpenChatButton();
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
 
   // Zustand
   const { isOpenAdminChat, openChat, closeChat, toggleChat } = useAdminChat();
@@ -74,6 +78,13 @@ function SidebarMenu() {
     onLinkClick('/projects');
   };
 
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
   return (
     <div className="flex flex-col items-start gap-4">
       <MenuButton
@@ -112,7 +123,7 @@ function SidebarMenu() {
           {!hasAcceptedChat ? (
             <MenuButton
               onClick={openChatModal}
-              aria="Go to Projects Button"
+              aria="Abrir Chat"
               icon={MessageCircleMoreIcon}
               text={t('sidebarMenu.chat')}
               textColor="text-emerald-400"

--- a/src/Stores/useOpenChatButton.js
+++ b/src/Stores/useOpenChatButton.js
@@ -1,46 +1,45 @@
 import { create } from 'zustand';
 
 export const useOpenChatButton = create((set) => ({
-  isPermitted:
-    typeof window !== 'undefined'
-      ? localStorage.getItem('isPermitted') === 'true'
-      : false,
-  hasAcceptedChat:
-    typeof window !== 'undefined'
-      ? localStorage.getItem('hasAcceptedChat') === 'true'
-      : false,
+  isPermitted: false,
+  hasAcceptedChat: false,
 
-  permitted: () =>
-    set(() => {
-      if (typeof window !== 'undefined') {
-        localStorage.setItem('isPermitted', 'true');
-      }
-      return { isPermitted: true };
-    }),
+  hydrate: () => {
+    if (typeof window !== 'undefined') {
+      set({
+        isPermitted: localStorage.getItem('isPermitted') === 'true',
+        hasAcceptedChat: localStorage.getItem('hasAcceptedChat') === 'true',
+      });
+    }
+  },
 
-  notPermitted: () =>
-    set(() => {
-      if (typeof window !== 'undefined') {
-        localStorage.setItem('isPermitted', 'false');
-      }
-      return { isPermitted: false };
-    }),
+  permitted: () => {
+    set({ isPermitted: true });
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('isPermitted', 'true');
+    }
+  },
+
+  notPermitted: () => {
+    set({ isPermitted: false });
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('isPermitted', 'false');
+    }
+  },
 
   toggleChat: () =>
     set((state) => {
-      const newValue = !state.isPermitted;
+      const newVal = !state.isPermitted;
       if (typeof window !== 'undefined') {
-        localStorage.setItem('isPermitted', newValue.toString());
+        localStorage.setItem('isPermitted', newVal ? 'true' : 'false');
       }
-      return { isPermitted: newValue };
+      return { isPermitted: newVal };
     }),
 
-  acceptChat: () =>
-    set(() => {
-      if (typeof window !== 'undefined') {
-        localStorage.setItem('hasAcceptedChat', 'true');
-        localStorage.setItem('isPermitted', 'true');
-      }
-      return { hasAcceptedChat: true, isPermitted: true };
-    }),
+  acceptChat: () => {
+    set({ hasAcceptedChat: true });
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('hasAcceptedChat', 'true');
+    }
+  },
 }));


### PR DESCRIPTION
Moved localStorage state hydration for chat button permissions into a dedicated hydrate function in useOpenChatButton store. Updated SidebarMenu and MenuButton components to call hydrate on mount, ensuring state consistency. Simplified acceptChat to only update hasAcceptedChat and improved toggleChat logic.